### PR TITLE
Validate Redis Stream alert input and exclude raw_data from LLM prompts (NDR Rule-05)

### DIFF
--- a/MODULES/NDR-Rule-05-Suspect-C2-Communication.py
+++ b/MODULES/NDR-Rule-05-Suspect-C2-Communication.py
@@ -1,12 +1,12 @@
 import json
 from datetime import datetime
-from typing import Optional, Union, Dict, Any, List
+from typing import Optional, Union, Dict, Any, List, Literal
 
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.graph import StateGraph, END
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import Command
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 from Lib.api import get_current_time_str
 from Lib.basemodule import LanggraphModule
@@ -14,6 +14,29 @@ from Lib.llmapi import BaseAgentState
 from PLUGINS.LLM.llmapi import LLMAPI
 from PLUGINS.SIRP.sirpapi import Alert
 from PLUGINS.SIRP.sirpmodel import AlertModel, ArtifactModel, ArtifactType, ArtifactRole, Severity, AlertStatus, AlertAnalyticType, ProductCategory, Confidence
+
+
+class NDRArtifactSchema(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = ""
+    value: str = ""
+
+
+class NDRAlertSchema(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Optional[str] = ""
+    rule_id: Optional[str] = ""
+    rule_name: Optional[str] = ""
+    alert_date: Optional[str] = ""
+    tags: Optional[List[str]] = []
+    severity: Optional[Literal["Critical", "High", "Medium", "Low", "Informational"]] = "Medium"
+    reference: Optional[str] = ""
+    description: Optional[str] = ""
+    id: Optional[str] = ""
+    artifact: Optional[List[NDRArtifactSchema]] = []
+    raw_log: Optional[Dict[str, Any]] = {}
 
 
 class AnalyzeResult(BaseModel):
@@ -47,7 +70,8 @@ class Module(LanggraphModule):
             if raw_message is None:
                 return Command(update={}, goto=END)
 
-            alert_raw = raw_message
+            validated = NDRAlertSchema.model_validate(raw_message)
+            alert_raw = validated.model_dump()
 
             artifacts_raw: list = alert_raw.get("artifact", [])
             alert_date: str = alert_raw.get("alert_date", "")

--- a/PLUGINS/SIRP/sirpmodel.py
+++ b/PLUGINS/SIRP/sirpmodel.py
@@ -623,7 +623,7 @@ class ArtifactModel(BaseSystemModel):
 
 
 class AlertModel(BaseSystemModel):
-    ai_exclude_fields: ClassVar[set[str]] = {'ownerid', 'caid', 'uaid', "comment_ai", "attachments"}
+    ai_exclude_fields: ClassVar[set[str]] = {'ownerid', 'caid', 'uaid', "comment_ai", "attachments", "raw_data", "unmapped"}
     id: Optional[str] = Field(default=None)
     severity: Optional[Severity] = Field(default=None,
                                          description="Source-defined severity")


### PR DESCRIPTION
## Summary

This PR hardens the NDR Rule-05 (Suspect C2 Communication) module against untrusted alert data being forwarded verbatim to the LLM. It addresses a prompt-injection / unsafe-deserialization-style risk (CWE-502 / CWE-20) where arbitrary attacker-controlled JSON fields entering through the Forwarder webhook reach the LLM prompt without validation.

## Vulnerability

- **File:** `MODULES/NDR-Rule-05-Suspect-C2-Communication.py`
- **Sink:** `alert.model_dump_json_for_ai()` passed as `HumanMessage` content to the LLM (lines ~297, 308, 325).
- **Source:** `PLUGINS/Forwarder/main.py` webhook endpoints (Splunk `result`, Kibana `_source`) — these accept arbitrary `Dict[str, Any]` and publish it to the Redis stream consumed by this module.
- **Data flow:** Webhook payload → Redis stream → `raw_message` → `AlertModel.raw_data` and `unmapped` (full JSON blobs) → `model_dump_json_for_ai()` → LLM prompt.

Before the fix, the entire untrusted JSON object was serialized into `raw_data` and `unmapped` and then included in the LLM context. An attacker with reachability to the (unauthenticated) Forwarder webhook could embed arbitrary instructions, fake severities, or fabricated context that the LLM would treat as part of the alert to analyze.

## Fix

Two minimal, targeted changes:

1. **`PLUGINS/SIRP/sirpmodel.py`** — Add `raw_data` and `unmapped` to `AlertModel.ai_exclude_fields`. `model_dump_for_ai` honors this set (it iterates `__dict__` and skips listed fields), so the raw upstream JSON blob is no longer included in any prompt sent to the LLM.

2. **`MODULES/NDR-Rule-05-Suspect-C2-Communication.py`** — Introduce `NDRAlertSchema` and `NDRArtifactSchema` Pydantic models with `extra="forbid"` and a `Literal` whitelist for `severity`. Incoming Redis messages are now validated and normalized before any field is consumed downstream. Unknown fields are rejected, and severity values outside the known set cannot be smuggled in.

The diff is 30 lines added / 4 changed across two files.

## Testing

- Verified the schema accepts well-formed messages produced by the existing Forwarder code paths (Splunk and Kibana shapes both fit the schema fields).
- Verified `extra="forbid"` rejects payloads with unknown top-level or artifact keys.
- Verified `model_dump_for_ai` excludes the new fields by reading the base implementation in `BaseSystemModel` — it skips any attribute name present in `ai_exclude_fields`.
- Confirmed that `raw_data` / `unmapped` are still persisted on the alert object for storage/audit purposes; only the LLM-facing serialization is affected.

## Security analysis

The Forwarder webhooks have no authentication, so any actor with network reachability to the service (or write access to the Redis stream) can inject messages. Prior to this patch that capability translated directly into LLM-prompt control via the `raw_data` blob. After this patch, the raw blob is no longer sent to the LLM, and unknown fields cannot ride along inside the validated structure.

Note: legitimate string fields such as `description`, `tags`, `rule_name`, and `artifact[].value` are still forwarded to the LLM (they have to be — that's the alert content the analyst agent reasons over). So this PR closes the wholesale-JSON-blob channel, not every conceivable prompt-injection vector. Defenders should still treat alert text as untrusted in downstream prompts; that is a broader hardening effort beyond this single module.

## Adversarial review

Before submitting, we tried to disprove this finding. We checked whether the Forwarder enforced authentication (it does not), whether `model_dump_for_ai` actually honors `ai_exclude_fields` (it does — confirmed in `BaseSystemModel`), and whether the preconditions to inject a Redis message would already grant equivalent capabilities such as LLM control or alert manipulation (they do not — network reach to the webhook is a strictly lower privilege than what the bug grants). We also considered whether the schema validation alone is sufficient against prompt injection: it isn't, and we call that out above so the limitation isn't overstated. The `ai_exclude_fields` change is the substantive mitigation; the schema reduces the unvalidated-input surface as a defense-in-depth measure.

cc @lewiswigmore
