### PR TITLE
Potential fix for code scanning alert no. 31: Information exposure through an exception

### DIFF
--- a/backend/apps/agentic/services/playbooks.py
+++ b/backend/apps/agentic/services/playbooks.py
@@ -150,7 +150,8 @@ def mark_playbook_failed(playbook, error):
     if locked.job_status != PlaybookJobStatus.RUNNING:
         raise ValueError(f"Playbook must be Running before failure, got {locked.job_status}")
     locked.job_status = PlaybookJobStatus.FAILED
-    locked.remark = f"{type(error).__name__}: {error}"
+    logger.exception("Playbook execution failed", exc_info=error)
+    locked.remark = "Playbook execution failed."
     locked.save(update_fields=["job_status", "remark", "updated_at"])
     notify_playbook_completion(locked)
     return locked


### PR DESCRIPTION
Potential fix for [https://github.com/FunnyWolf/agentic-soc-platform/security/code-scanning/31](https://github.com/FunnyWolf/agentic-soc-platform/security/code-scanning/31)

The safest fix is to **stop propagating raw exception content into `Playbook.remark`**, while still preserving server-side diagnostics through logging.

Best targeted fix (without changing existing API structure/functionality):
- Edit `backend/apps/agentic/services/playbooks.py` in `mark_playbook_failed`.
- Replace the current assignment:
  - `locked.remark = f"{type(error).__name__}: {error}"`
- With a generic, non-sensitive message, e.g.:
  - `locked.remark = "Playbook execution failed."`
- Add server-side logging of exception details using the existing `logger`:
  - `logger.exception("Playbook execution failed", exc_info=error)`

This keeps the `remark` field and API response contract intact, but removes sensitive exception details from user-visible output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
